### PR TITLE
Bump JS-based actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -33,7 +33,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -26,7 +26,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -45,7 +45,7 @@ jobs:
 
       - name: Deploy to GitHub pages
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        uses: JamesIves/github-pages-deploy-action@v4.7.3
         with:
           clean: false
           branch: gh-pages

--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -15,7 +15,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/pr-fetch@v2
         with:
@@ -55,7 +55,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/pr-fetch@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -17,7 +17,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -38,7 +38,7 @@ jobs:
           covr::to_cobertura(cov)
         shell: Rscript {0}
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: ${{ github.event_name != 'pull_request' && true || false }}
           file: ./cobertura.xml

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,9 +4,13 @@
   repo and the templates in `inst/templates/ci_github-actions/`) so that
   they run on current GitHub-hosted runners again:
 
-  - Bump action versions: `actions/checkout@v4`, `actions/upload-artifact@v4`,
-    `codecov/codecov-action@v4`, and replace the deprecated `r-lib/actions@master`
-    references with `r-lib/actions@v2`.
+  - Bump action versions: `actions/checkout@v5`, `actions/upload-artifact@v4`,
+    `codecov/codecov-action@v5`, `JamesIves/github-pages-deploy-action@v4.7.3`,
+    and replace the deprecated `r-lib/actions@master` references with
+    `r-lib/actions@v2`. The `@v5` / `@v4.7.3` bumps run on Node.js 24 and
+    avoid the GitHub deprecation warning for Node.js 20 actions
+    (forced default June 2026, removed September 2026, see
+    https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).
 
   - Switch from the retired `ubuntu-20.04` runner to `ubuntu-latest` and
     rename the matrix entry `oldrel` to `oldrel-1`.

--- a/inst/templates/ci_github-actions-claude/claude-code-review.yaml
+++ b/inst/templates/ci_github-actions-claude/claude-code-review.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/inst/templates/ci_github-actions-claude/claude.yaml
+++ b/inst/templates/ci_github-actions-claude/claude.yaml
@@ -26,7 +26,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/inst/templates/ci_github-actions/R-CMD-check.yaml
+++ b/inst/templates/ci_github-actions/R-CMD-check.yaml
@@ -33,7 +33,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/inst/templates/ci_github-actions/pkgdown.yaml
+++ b/inst/templates/ci_github-actions/pkgdown.yaml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -45,7 +45,7 @@ jobs:
 
       - name: Deploy to GitHub pages
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        uses: JamesIves/github-pages-deploy-action@v4.7.3
         with:
           clean: false
           branch: gh-pages

--- a/inst/templates/ci_github-actions/pr-commands.yaml
+++ b/inst/templates/ci_github-actions/pr-commands.yaml
@@ -15,7 +15,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/pr-fetch@v2
         with:
@@ -55,7 +55,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/pr-fetch@v2
         with:

--- a/inst/templates/ci_github-actions/test-coverage.yaml
+++ b/inst/templates/ci_github-actions/test-coverage.yaml
@@ -17,7 +17,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -38,7 +38,7 @@ jobs:
           covr::to_cobertura(cov)
         shell: Rscript {0}
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: ${{ github.event_name != 'pull_request' && true || false }}
           file: ./cobertura.xml


### PR DESCRIPTION
GitHub deprecated Node.js 20 on hosted runners (forced default June 2026, removed September 2026). Bump the JavaScript-based actions used in our workflows to versions that ship a Node 24 runner so the deprecation warning goes away:

- actions/checkout@v4                            -> @v5
- codecov/codecov-action@v4                      -> @v5
- JamesIves/github-pages-deploy-action@v4.5.0    -> @v4.7.3

Apply the same changes to the templates in inst/templates/ so newly bootstrapped packages start out on Node 24-compatible actions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/KWB-R/kwb.pkgbuild/97)
<!-- Reviewable:end -->
